### PR TITLE
Tweak to keep it from polluting the browser's global namespace.

### DIFF
--- a/colors.js
+++ b/colors.js
@@ -25,7 +25,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 */
-
+(function(module, exports){
 var isHeadless = false;
 
 if (typeof module !== 'undefined') {
@@ -302,3 +302,4 @@ function zalgo(text, options) {
 addProperty('zalgo', function () {
   return zalgo(this);
 });
+})(typeof module == 'undefined' ? undefined : module, typeof exports == 'undefined' ? undefined : exports);


### PR DESCRIPTION
With it setting module and export in the global namespace it was conflicting with other libs in the browser. Example: If socket.io was included after this, socket.io would think it was running in node because of the global declared module and export variables.
