### PR TITLE
being gentle with output of non-TTY consoles

### DIFF
--- a/colors.js
+++ b/colors.js
@@ -57,7 +57,7 @@ function stylize(str, style) {
 
   var styles;
 
-  if (exports.mode === 'console' && process.stdout.isTTY) {
+  if (exports.mode === 'console' && process.stdout.isTTY || exports.mode === 'console-forced') {
     styles = {
       //styles
       'bold'      : ['\033[1m',  '\033[22m'],

--- a/test.js
+++ b/test.js
@@ -56,6 +56,26 @@ stylesAll.forEach(function (style) {
 });
 process.stdout.isTTY = true;
 
+/* although "console-forced" will still output the ANSI characters */
+colors.mode = 'console-forced';
+process.stdout.isTTY = false;
+assert.equal(s.bold, '\033[1m' + s + '\033[22m');
+assert.equal(s.italic, '\033[3m' + s + '\033[23m');
+assert.equal(s.underline, '\033[4m' + s + '\033[24m');
+assert.equal(s.inverse, '\033[7m' + s + '\033[27m');
+assert.ok(s.rainbow);
+aE(s, 'white', 37);
+aE(s, 'grey', 90);
+aE(s, 'black', 30);
+aE(s, 'blue', 34);
+aE(s, 'cyan', 36);
+aE(s, 'green', 32);
+aE(s, 'magenta', 35);
+aE(s, 'red', 31);
+aE(s, 'yellow', 33);
+assert.equal(s, 'string');
+
+process.stdout.isTTY = true;
 colors.mode = 'browser';
 assert.equal(s.bold, '<b>' + s + '</b>');
 assert.equal(s.italic, '<i>' + s + '</i>');


### PR DESCRIPTION
Hi there,

first of all thanks for this nifty module, it's very handy in so many ways.

This pull request is just to avoid problems when you spawn a child node.js process that make use of ANSI characters.

For example, if you consider a server that spawns a node.js process that uses `colors.js` and log the stdout to a file, the log will be clutered by the escaped ANSI chars.

I truly believe this will have a huge positive impact on all the node.js modules that make use of `colors.js`
