### PR TITLE
Changed octal literals to hexadecimal

### DIFF
--- a/colors.js
+++ b/colors.js
@@ -62,21 +62,21 @@ function stylize(str, style) {
   if (exports.mode === 'console') {
     styles = {
       //styles
-      'bold'      : ['\033[1m',  '\033[22m'],
-      'italic'    : ['\033[3m',  '\033[23m'],
-      'underline' : ['\033[4m',  '\033[24m'],
-      'inverse'   : ['\033[7m',  '\033[27m'],
+      'bold'      : ['\x1B[1m',  '\x1B[22m'],
+      'italic'    : ['\x1B[3m',  '\x1B[23m'],
+      'underline' : ['\x1B[4m',  '\x1B[24m'],
+      'inverse'   : ['\x1B[7m',  '\x1B[27m'],
       //grayscale
-      'white'     : ['\033[37m', '\033[39m'],
-      'grey'      : ['\033[90m', '\033[39m'],
-      'black'     : ['\033[30m', '\033[39m'],
+      'white'     : ['\x1B[37m', '\x1B[39m'],
+      'grey'      : ['\x1B[90m', '\x1B[39m'],
+      'black'     : ['\x1B[30m', '\x1B[39m'],
       //colors
-      'blue'      : ['\033[34m', '\033[39m'],
-      'cyan'      : ['\033[36m', '\033[39m'],
-      'green'     : ['\033[32m', '\033[39m'],
-      'magenta'   : ['\033[35m', '\033[39m'],
-      'red'       : ['\033[31m', '\033[39m'],
-      'yellow'    : ['\033[33m', '\033[39m']
+      'blue'      : ['\x1B[34m', '\x1B[39m'],
+      'cyan'      : ['\x1B[36m', '\x1B[39m'],
+      'green'     : ['\x1B[32m', '\x1B[39m'],
+      'magenta'   : ['\x1B[35m', '\x1B[39m'],
+      'red'       : ['\x1B[31m', '\x1B[39m'],
+      'yellow'    : ['\x1B[33m', '\x1B[39m']
     };
   } else if (exports.mode === 'browser') {
     styles = {
@@ -194,7 +194,7 @@ exports.setTheme = function (theme) {
 
 
 addProperty('stripColors', function () {
-  return ("" + this).replace(/\u001b\[\d+m/g, '');
+  return ("" + this).replace(/\x1B\[\d+m/g, '');
 });
 
 // please no

--- a/test.js
+++ b/test.js
@@ -10,7 +10,7 @@ var assert = require('assert'),
 var s = 'string';
 
 function a(s, code) {
-  return '\033[' + code.toString() + 'm' + s + '\033[39m';
+  return '\x1B[' + code.toString() + 'm' + s + '\x1B[39m';
 }
 
 function aE(s, color, code) {
@@ -30,10 +30,10 @@ var stylesColors = ['white', 'grey', 'black', 'blue', 'cyan', 'green', 'magenta'
 var stylesAll = stylesColors.concat(['bold', 'italic', 'underline', 'inverse', 'rainbow']);
 
 colors.mode = 'console';
-assert.equal(s.bold, '\033[1m' + s + '\033[22m');
-assert.equal(s.italic, '\033[3m' + s + '\033[23m');
-assert.equal(s.underline, '\033[4m' + s + '\033[24m');
-assert.equal(s.inverse, '\033[7m' + s + '\033[27m');
+assert.equal(s.bold, '\x1B[1m' + s + '\x1B[22m');
+assert.equal(s.italic, '\x1B[3m' + s + '\x1B[23m');
+assert.equal(s.underline, '\x1B[4m' + s + '\x1B[24m');
+assert.equal(s.inverse, '\x1B[7m' + s + '\x1B[27m');
 assert.ok(s.rainbow);
 aE(s, 'white', 37);
 aE(s, 'grey', 90);


### PR DESCRIPTION
Octal literals are not allowed in strict mode.
Replaced the only unicode escape sequence for consistency.
