### PR TITLE
Do not redefine String.prototype if it has been already defined

### DIFF
--- a/colors.js
+++ b/colors.js
@@ -48,9 +48,11 @@ var addProperty = function (color, func) {
   exports[color] = function (str) {
     return func.apply(str);
   };
-  Object.defineProperty(String.prototype, color, {
-    get: func
-  });
+  if (String.prototype[color] === undefined) {
+    Object.defineProperty(String.prototype, color, {
+      get: func
+    });
+  }
 };
 
 


### PR DESCRIPTION
This fixes #32
