### PR TITLE
Add 'auto' mode that only adds colors for the terminal

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -34,6 +34,10 @@ console.log('hello'.green); // outputs green text
 console.log('i like cake and pies'.underline.red) // outputs red underlined text
 console.log('inverse the color'.inverse); // inverses the color
 console.log('OMG Rainbows!'.rainbow); // rainbow (ignores spaces)
+
+colors.mode = 'auto';
+console.log('hello'.green); // outputs green text only if stdout is not being
+                            // redirected
 ```
 
 # Creating Custom themes

--- a/colors.js
+++ b/colors.js
@@ -41,6 +41,7 @@ if (!isHeadless) {
   exports.mode = "console";
 }
 
+
 //
 // Prototypes the string object to have additional method calls that add terminal colors
 //
@@ -58,6 +59,11 @@ var addProperty = function (color, func) {
 function stylize(str, style) {
 
   var styles;
+
+  if (exports.mode === 'auto') {
+    var isStdoutTty = require('tty').isatty(process.stdout.fd);
+    exports.mode = isStdoutTty ? 'console' : 'none';
+  }
 
   if (exports.mode === 'console') {
     styles = {


### PR DESCRIPTION
If the mode is set to 'auto', then escaping will only happen if stdout is a TTY
(terminal).  If stdout is redirected somewhere, strings will not be modified by
the colorize functions.