### PR TITLE
Added a disable() method.

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -62,6 +62,13 @@ console.log("this is an error".error);
 console.log("this is a warning".warn);
 ```
 
+# Disable colors.js
+
+This is useful if you want to remove the colors from the output of an external lib, for logging, for example. It works globally.
+
+```
+colors.disable();
+```
 
 ### Contributors 
 
@@ -72,6 +79,7 @@ nicoreed (Nico Reed)
 morganrallen (Morgan Allen)
 JustinCampbell (Justin Campbell)
 ded (Dustin Diaz)
+pygy (Pierre-Yves Gérardy)
 
 
 ####  , Marak Squires , Justin Campbell, Dustin Diaz (@ded)

--- a/colors.js
+++ b/colors.js
@@ -49,7 +49,8 @@ var addProperty = function (color, func) {
     return func.apply(str);
   };
   Object.defineProperty(String.prototype, color, {
-    get: func
+    get: func,
+    configurable: true
   });
 };
 
@@ -192,6 +193,25 @@ exports.setTheme = function (theme) {
   }
 };
 
+var exported = [
+  'wipe', 'themes', 'addSequencer', 'setTheme'
+].reduce(function(set,f) {
+  set[f] = true;
+  return set;
+}, {});
+
+var returnThis = function () { return '' + this; };
+
+exports.disable = function () {
+  for (color in exports) {
+    if (exports.hasOwnProperty(color) && !exported[color]) {
+      addProperty(color, returnThis);
+    }
+  }
+  exports.addSequencer = function (name, map) {
+    addProperty(name, returnThis);
+  };
+};
 
 addProperty('stripColors', function () {
   return ("" + this).replace(/\x1B\[\d+m/g, '');


### PR DESCRIPTION
`colors.disable()`

This is useful if you want to remove the colors from the output of an external lib, for logging, for example. It works globally.
