### PR TITLE
Change 'grey' to 'gray' in HTML/CSS output

### DIFF
--- a/colors.js
+++ b/colors.js
@@ -87,7 +87,7 @@ function stylize(str, style) {
       'strikethrough' : ['<del>',  '</del>'],
       //grayscale
       'white'     : ['<span style="color:white;">',   '</span>'],
-      'grey'      : ['<span style="color:grey;">',    '</span>'],
+      'grey'      : ['<span style="color:gray;">',    '</span>'],
       'black'     : ['<span style="color:black;">',   '</span>'],
       //colors
       'blue'      : ['<span style="color:blue;">',    '</span>'],


### PR DESCRIPTION
Most browsers support both 'grey' and 'gray' in CSS, but only IE8+.

Source: https://developer.mozilla.org/en-US/docs/CSS/color_value#1
