### PR TITLE
Fix issue #50 : Added check/implementation for defineProperty over __defineGetter__

### DIFF
--- a/colors.js
+++ b/colors.js
@@ -48,7 +48,16 @@ var addProperty = function (color, func) {
   exports[color] = function (str) {
     return func.apply(str);
   };
-  String.prototype.__defineGetter__(color, func);
+
+  if (Object.defineProperty) {
+    Object.defineProperty(Object.prototype, color, {
+      get : func,
+      configurable: true,
+      enumerable: false
+    });
+  } else {
+      String.prototype.__defineGetter__(color, func);
+  }
 };
 
 


### PR DESCRIPTION
See issue #50: 

https://github.com/Marak/colors.js/issues/50
...
defineProperty is the correct way to add color properties so they aren't enumerable. Unintentional enumerable properties can cause global issues
