### PR TITLE
Use String.prototype instead of Object.prototype in defineProperty

### DIFF
--- a/colors.js
+++ b/colors.js
@@ -50,7 +50,7 @@ var addProperty = function (color, func) {
   };
 
   if (Object.defineProperty) {
-    Object.defineProperty(Object.prototype, color, {
+    Object.defineProperty(String.prototype, color, {
       get : func,
       configurable: true,
       enumerable: false


### PR DESCRIPTION
The commit 6045347a38dd93875e0b3b48f9b5e65743b38ea8 wrongly changes the prototype of `Object` instead of `String`. This broke logging in my app.
