### PR TITLE
Added optional environment variable mode-override

### DIFF
--- a/colors.js
+++ b/colors.js
@@ -38,7 +38,7 @@ if (!isHeadless) {
   var colors = exports;
   exports.mode = "browser";
 } else {
-  exports.mode = "console";
+  exports.mode = process.env.COLORS_JS_MODE || "console";
 }
 
 //


### PR DESCRIPTION
Some editors or platforms use the stdout as given without being properly identifiable. As a workaround I added a environment variable that would act as a mode override and could be set when launching the applications.