### PR TITLE
use defineProperty

### DIFF
--- a/lib/extendStringPrototype.js
+++ b/lib/extendStringPrototype.js
@@ -7,7 +7,11 @@ module['exports'] = function () {
   // Extends prototype of native string object to allow for "foo".red syntax
   //
   var addProperty = function (color, func) {
-    String.prototype.__defineGetter__(color, func);
+    Object.defineProperty (String.prototype, color, {
+      enumerable:    false,
+      configurable:  false,
+      get:           func
+    });
   };
 
   var sequencer = function sequencer (map, str) {


### PR DESCRIPTION
Using `__defineGetter__` results in enumerable properties. That means if you do this...

``` javascript
var str = "This is my String. There are many like it but this one is mine.";
for (var i in str)
    console.log (str[i]);
```

You don't just get the characters in your String, you also get a bunch of keys like 'cyan' and 'zalgo'.

This simple patch uses `defineProperty` instead and sets `enumerable` to `false`.
