### PR TITLE
Use the options when summoning Zalgo

### DIFF
--- a/lib/custom/zalgo.js
+++ b/lib/custom/zalgo.js
@@ -58,10 +58,10 @@ module['exports'] = function zalgo(text, options) {
   function heComes(text, options) {
     var result = '', counts, l;
     options = options || {};
-    options["up"] = options["up"] || true;
-    options["mid"] = options["mid"] || true;
-    options["down"] = options["down"] || true;
-    options["size"] = options["size"] || "maxi";
+    options["up"] =   typeof options["up"]   !== 'undefined' ? options["up"]   : true;
+    options["mid"] =  typeof options["mid"]  !== 'undefined' ? options["mid"]  : true;
+    options["down"] = typeof options["down"] !== 'undefined' ? options["down"] : true;
+    options["size"] = typeof options["size"] !== 'undefined' ? options["size"] : "maxi";
     text = text.split('');
     for (l in text) {
       if (is_char(l)) {
@@ -72,12 +72,12 @@ module['exports'] = function zalgo(text, options) {
       switch (options.size) {
       case 'mini':
         counts.up = randomNumber(8);
-        counts.min = randomNumber(2);
+        counts.mid = randomNumber(2);
         counts.down = randomNumber(8);
         break;
       case 'maxi':
         counts.up = randomNumber(16) + 3;
-        counts.min = randomNumber(4) + 1;
+        counts.mid = randomNumber(4) + 1;
         counts.down = randomNumber(64) + 3;
         break;
       default:

--- a/lib/custom/zalgo.js
+++ b/lib/custom/zalgo.js
@@ -100,5 +100,5 @@ module['exports'] = function zalgo(text, options) {
     return result;
   }
   // don't summon him
-  return heComes(text);
+  return heComes(text, options);
 }


### PR DESCRIPTION
The `options` argument in the `zalgo(text,options)` function never makes it to the `heComes(text,options)` function. This PR fixes that.