### PR TITLE
Added check in extended String.prototype version

### DIFF
--- a/lib/extendStringPrototype.js
+++ b/lib/extendStringPrototype.js
@@ -19,7 +19,7 @@ module['exports'] = function () {
   };
 
   var stylize = function stylize (str, style) {
-    return styles[style].open + str + styles[style].close;
+    return colors.enabled ? styles[style].open + str + styles[style].close : str;
   }
 
   addProperty('strip', function () {

--- a/tests/basic-test.js
+++ b/tests/basic-test.js
@@ -48,3 +48,7 @@ colors.setTheme({error:'red'});
 assert.equal(typeof("astring".red),'string');
 assert.equal(typeof("astring".error),'string');
 
+colors.enabled = false;
+
+assert.equal('some string'.red, 'some string');
+assert.equal(colors.red('some string'), 'some string');


### PR DESCRIPTION
Stylize method in extendingStringPrototype.js did not check for --no-color arguments.