### PR TITLE
Disable prototype methods when disabled

### DIFF
--- a/lib/extendStringPrototype.js
+++ b/lib/extendStringPrototype.js
@@ -18,10 +18,14 @@ module['exports'] = function () {
       }
   };
 
-  var stylize = function stylize (str, style) {
-    return styles[style].open + str + styles[style].close;
-  }
+  var stylize = function stylize (str, style) { return str.valueOf(); };
 
+  if (colors.enabled) {
+    stylize = function stylize (str, style) {
+      return styles[style].open + str + styles[style].close;
+    }
+  }
+  
   addProperty('strip', function () {
     return colors.strip(this);
   });


### PR DESCRIPTION
Currently the prototype additions to string don't seem to be disabled appropriately when not in a tty session.  Following test case demonstrates:

    ecornelius@ecornelius-T5-XE ~/Repositories/Posh % cat test.js 
    #!/usr/bin/env node
    
    var colors = require('colors');
    console.log(colors.enabled);
    
    console.log('test'.red);
    
    ecornelius@ecornelius-T5-XE ~/Repositories/Posh % ./test.js 
    true
    test [red]

    ecornelius@ecornelius-T5-XE ~/Repositories/Posh % ./test.js --no-color
    false
    test [red]