### PR TITLE
Make supports-colors.js browserify-compatible

### DIFF
--- a/lib/system/supports-colors.js
+++ b/lib/system/supports-colors.js
@@ -23,7 +23,7 @@ THE SOFTWARE.
 
 */
 
-var argv = process.argv;
+var argv = process.argv || "";
 
 module.exports = (function () {
   if (argv.indexOf('--no-color') !== -1 ||
@@ -44,8 +44,12 @@ module.exports = (function () {
   if (process.platform === 'win32') {
     return true;
   }
+  
+  if (!process.env) {
+    return false;
+  }
 
-  if ('COLORTERM' in process.env) {
+  if (process.env['COLORTERM']) {
     return true;
   }
 


### PR DESCRIPTION
Update supports-colors.js to make it browserify-compatible as well as whole package
