### PR TITLE
Added check in supports-colors.js

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,6 +1,15 @@
+# THIS IS A FORK, ADDS JETBRAINS IDE COMPATIBILITY
+
 > This is a fork of the original "colors" module that fixes an issue with color output in JetBrains
- IDE's. A pull request has been made on the original repo but has not yet been merged. While we wait
- for merge, this repo will exist to allow a drop-in replacement with JetBrains support.
+ IDE's. A pull request (https://github.com/Marak/colors.js/pull/150) has been made on the original
+ repo but has not yet been merged. While we wait for merge, this repo will exist to allow a drop-in
+ replacement with JetBrains support.
+ 
+You can use this forked version of colors as a drop-in replacement via:
+
+```bash
+npm install irrelon-colors
+```
 
 # colors.js [![Build Status](https://travis-ci.org/Marak/colors.js.svg?branch=master)](https://travis-ci.org/Marak/colors.js)
 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,3 +1,7 @@
+> This is a fork of the original "colors" module that fixes an issue with color output in JetBrains
+ IDE's. A pull request has been made on the original repo but has not yet been merged. While we wait
+ for merge, this repo will exist to allow a drop-in replacement with JetBrains support.
+
 # colors.js [![Build Status](https://travis-ci.org/Marak/colors.js.svg?branch=master)](https://travis-ci.org/Marak/colors.js)
 
 ## get color and style in your node.js console
@@ -6,7 +10,7 @@
 
 ## Installation
 
-    npm install colors
+    npm install irrelon-colors
 
 ## colors and styles!
 
@@ -61,7 +65,7 @@ By popular demand, `colors` now ships with two types of usages!
 The super nifty way
 
 ```js
-var colors = require('colors');
+var colors = require('irrelon-colors');
 
 console.log('hello'.green); // outputs green text
 console.log('i like cake and pies'.underline.red) // outputs red underlined text
@@ -74,7 +78,7 @@ console.log('Run the trap'.trap); // Drops the bass
 or a slightly less nifty way which doesn't extend `String.prototype`
 
 ```js
-var colors = require('colors/safe');
+var colors = require('irrelon-colors/safe');
 
 console.log(colors.green('hello')); // outputs green text
 console.log(colors.red.underline('i like cake and pies')) // outputs red underlined text
@@ -110,7 +114,7 @@ console.log(colors.green('Hello %s'), name);
 
 ```js
 
-var colors = require('colors');
+var colors = require('irrelon-colors');
 
 colors.setTheme({
   silly: 'rainbow',
@@ -135,7 +139,7 @@ console.log("this is a warning".warn);
 ### Using string safe API
 
 ```js
-var colors = require('colors/safe');
+var colors = require('irrelon-colors/safe');
 
 // set single property
 var error = colors.red;
@@ -166,7 +170,7 @@ console.log(colors.warn("this is a warning"));
 ### Combining Colors
 
 ```javascript
-var colors = require('colors');
+var colors = require('irrelon-colors');
 
 colors.setTheme({
   custom: ['red', 'underline']

--- a/lib/system/supports-colors.js
+++ b/lib/system/supports-colors.js
@@ -36,6 +36,10 @@ module.exports = (function () {
     argv.indexOf('--color=always') !== -1) {
     return true;
   }
+  
+  if (process.env['ALLOW_COLORS']) {
+    return true;
+  }
 
   if (process.stdout && !process.stdout.isTTY) {
     return false;

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
-    "name": "colors",
-    "description": "get colors in your node.js console",
-    "version": "1.1.2",
-    "author": "Marak Squires",
-    "homepage": "https://github.com/Marak/colors.js",
-    "bugs": "https://github.com/Marak/colors.js/issues",
+    "name": "irrelon-colors",
+    "description": "Get colors in your node.js console",
+    "version": "1.0.0",
+    "author": "Irrelon Software Limited",
+    "homepage": "https://github.com/irrelon/colors.js",
+    "bugs": "https://github.com/irrelon/colors.js/issues",
     "keywords": [ "ansi", "terminal", "colors" ],
     "repository": {
         "type": "git",
-        "url": "http://github.com/Marak/colors.js.git"
+        "url": "http://github.com/irrelon/colors.js.git"
     },
     "license": "MIT",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -3,12 +3,12 @@
     "description": "Get colors in your node.js console",
     "version": "1.0.0",
     "author": "Irrelon Software Limited",
-    "homepage": "https://github.com/irrelon/colors.js",
-    "bugs": "https://github.com/irrelon/colors.js/issues",
+    "homepage": "https://github.com/irrelon/irrelon-colors",
+    "bugs": "https://github.com/irrelon/irrelon-colors/issues",
     "keywords": [ "ansi", "terminal", "colors" ],
     "repository": {
         "type": "git",
-        "url": "http://github.com/irrelon/colors.js.git"
+        "url": "http://github.com/irrelon/irrelon-colors.git"
     },
     "license": "MIT",
     "scripts": {


### PR DESCRIPTION
Added environment variable check that can override other checks in supports-colors.js so if we set process.env.ALLOW_COLORS = true it will enable colour output.

This fixes the issue of IDEs not showing colors because the process.stdout.isTTY is false as per issue #148 