### PR TITLE
fixed support-colors condition orders, this should fix cygwin issues

### DIFF
--- a/lib/system/supports-colors.js
+++ b/lib/system/supports-colors.js
@@ -37,10 +37,6 @@ module.exports = (function () {
     return true;
   }
 
-  if (process.stdout && !process.stdout.isTTY) {
-    return false;
-  }
-
   if (process.platform === 'win32') {
     return true;
   }
@@ -49,12 +45,16 @@ module.exports = (function () {
     return true;
   }
 
-  if (process.env.TERM === 'dumb') {
+  if (/^screen|^xterm|^vt100|color|ansi|cygwin|linux/i.test(process.env.TERM)) {
+    return true;
+  }
+
+  if (process.stdout && !process.stdout.isTTY) {
     return false;
   }
 
-  if (/^screen|^xterm|^vt100|color|ansi|cygwin|linux/i.test(process.env.TERM)) {
-    return true;
+  if (process.env.TERM === 'dumb') {
+    return false;
   }
 
   return false;


### PR DESCRIPTION
Support-colors.js's condition order was a mess.
Changed to make it fit to logical rules, instead of randomness.
