### PR TITLE
Able to use extras when stylizing based on name

### DIFF
--- a/lib/colors.js
+++ b/lib/colors.js
@@ -2,7 +2,7 @@
 
 The MIT License (MIT)
 
-Original Library 
+Original Library
   - Copyright (c) Marak Squires
 
 Additional functionality
@@ -50,6 +50,14 @@ colors.stripColors = colors.strip = function(str){
 var stylize = colors.stylize = function stylize (str, style) {
   if (!colors.enabled) {
     return str+'';
+  }
+
+  if(style in colors){
+    return colors[style](str);
+  }
+
+  if(style in colors.maps){
+    return colors[style](str);
   }
 
   return ansiStyles[style].open + str + ansiStyles[style].close;

--- a/tests/basic-test.js
+++ b/tests/basic-test.js
@@ -31,6 +31,12 @@ assert.equal(s.inverse, '\x1B[7m' + s + '\x1B[27m');
 
 assert.ok(s.rainbow);
 
+assert.ok(colors.stylize(s, "rainbow"))
+assert.ok(colors.stylize(s, "america"))
+assert.ok(colors.stylize(s, "zebra"))
+assert.ok(colors.stylize(s, "trap"))
+assert.ok(colors.stylize(s, "random"))
+
 aE(s, 'white', 37);
 aE(s, 'grey', 90);
 aE(s, 'black', 30);
@@ -47,4 +53,3 @@ colors.setTheme({error:'red'});
 
 assert.equal(typeof("astring".red),'string');
 assert.equal(typeof("astring".error),'string');
-


### PR DESCRIPTION
Added the ability to stylize a string based on the name of a style. The normal styles already had this functionality so i added the corresponding functionality to the customs and the maps.

with corresponding test.
