### PR TITLE
Remove --color=true

### DIFF
--- a/lib/system/supports-colors.js
+++ b/lib/system/supports-colors.js
@@ -31,9 +31,8 @@ module.exports = (function () {
     return false;
   }
 
-  if (argv.indexOf('--color') !== -1 ||
-    argv.indexOf('--color=true') !== -1 ||
-    argv.indexOf('--color=always') !== -1) {
+  if (!argv.indexOf('--no-color') !== -1 ||
+    !argv.indexOf('--color=false') !== -1) {
     return true;
   }
 


### PR DESCRIPTION
Reason since you can either use --color=false to disable colors or use colors which should be on by default without needing to use a config.

1.x release broke grunt see https://github.com/gruntjs/grunt-legacy-log/pull/16

So instead if it detect that --color=false or --no-color are not be using then it will switch colors on by default like it use too.