### PR TITLE
Added check in supports-colors.js to check for an environment variable

### DIFF
--- a/lib/system/supports-colors.js
+++ b/lib/system/supports-colors.js
@@ -36,6 +36,10 @@ module.exports = (function () {
     argv.indexOf('--color=always') !== -1) {
     return true;
   }
+  
+  if (process.env['ALLOW_COLORS']) {
+    return true;
+  }
 
   if (process.stdout && !process.stdout.isTTY) {
     return false;


### PR DESCRIPTION
Environment variable ALLOW_COLORS added to checks, if set will return true in supports-colors so that we can override other checks if ENV variable is set.

This is useful for enabling support in JetBrains IDEs.
