### PR TITLE
 Adding badges npm, dependencies and devDependencies

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,4 +1,8 @@
-# colors.js [![Build Status](https://travis-ci.org/Marak/colors.js.svg?branch=master)](https://travis-ci.org/Marak/colors.js)
+# colors.js
+[![Build Status](https://travis-ci.org/Marak/colors.js.svg?branch=master)](https://travis-ci.org/Marak/colors.js)
+[![version](https://img.shields.io/npm/v/colors.svg)](https://www.npmjs.org/package/colors)
+[![dependencies](https://david-dm.org/Marak/colors.js.svg)](https://david-dm.org/Marak/colors.js)
+[![devDependencies](https://david-dm.org/Marak/colors.js/dev-status.svg)](https://david-dm.org/Marak/colors.js#info=devDependencies)
 
 ## get color and style in your node.js console
 


### PR DESCRIPTION
The "dependencies" and "devDependencies" badges are useful because they show that there are no external dependencies. The "npm" badge is useful as it allows to realize that the package is available on NPM.