### PR TITLE
Added check for argv being null

### DIFF
--- a/lib/system/supports-colors.js
+++ b/lib/system/supports-colors.js
@@ -26,6 +26,10 @@ THE SOFTWARE.
 var argv = process.argv;
 
 module.exports = (function () {
+  if(argv == null) {
+    return false;
+  }
+  
   if (argv.indexOf('--no-color') !== -1 ||
     argv.indexOf('--color=false') !== -1) {
     return false;


### PR DESCRIPTION
When process.argv is null, it shows "Cannot read property 'indexOf' of undefined".