### PR TITLE
Remove setTheme dynamic require(...) that is problematic with webpack

### DIFF
--- a/examples/normal-usage.js
+++ b/examples/normal-usage.js
@@ -60,7 +60,11 @@ console.log("this is an input".input);
 console.log('Generic logging theme as file'.green.bold.underline);
 
 // Load a theme from file
-colors.setTheme(__dirname + '/../themes/generic-logging.js');
+try {
+  colors.setTheme(require(__dirname + '/../themes/generic-logging.js'));
+} catch (err) {
+  console.log(err);
+}
 
 // outputs red text
 console.log("this is an error".error);

--- a/lib/colors.js
+++ b/lib/colors.js
@@ -115,7 +115,7 @@ function applyStyle() {
   return str;
 }
 
-function applyTheme (theme) {
+colors.setTheme = function (theme) {
   for (var style in theme) {
     (function(style){
       colors[style] = function(str){
@@ -131,21 +131,6 @@ function applyTheme (theme) {
     })(style)
   }
 }
-
-colors.setTheme = function (theme) {
-  if (typeof theme === 'string') {
-    try {
-      colors.themes[theme] = require(theme);
-      applyTheme(colors.themes[theme]);
-      return colors.themes[theme];
-    } catch (err) {
-      console.log(err);
-      return err;
-    }
-  } else {
-    applyTheme(theme);
-  }
-};
 
 function init() {
   var ret = {};

--- a/lib/colors.js
+++ b/lib/colors.js
@@ -116,6 +116,13 @@ function applyStyle() {
 }
 
 colors.setTheme = function (theme) {
+  if (typeof theme === 'string') {
+    console.log('colors.setTheme now only accepts an object, not a string.  ' +
+      'If you are trying to set a theme from a file, it is now your (the caller\'s) responsibility to require the file.  ' +
+      'The old syntax looked like colors.setTheme(__dirname + \'/../themes/generic-logging.js\'); ' +
+      'The new syntax looks like colors.setTheme(require(__dirname + \'/../themes/generic-logging.js\'));');
+    return;
+  }
   for (var style in theme) {
     (function(style){
       colors[style] = function(str){


### PR DESCRIPTION
Addresses #200, #137.

The `setTheme` method is refactored to remove the ability to import directly from a file; it is now the caller's responsibility to create a theme object to pass as the single argument.  The example showing the old behavior has been refactored to suit.

I chose to refactor in this way because the method of setting the theme from a file was not documented in the README and it appears not be a usual use-case in general.