### PR TITLE
Add "bright" ANSI color styles.

### DIFF
--- a/lib/styles.js
+++ b/lib/styles.js
@@ -47,6 +47,15 @@ var codes = {
   white: [37, 39],
   gray: [90, 39],
   grey: [90, 39],
+  
+  brightBlack: [90, 39],
+  brightRed: [91, 39],
+  brightGreen: [92, 39],
+  brightYellow: [93, 39],
+  brightBlue: [94, 39],
+  brightMagenta: [95, 39],
+  brightCyan: [96, 39],
+  brightWhite: [97, 39],
 
   bgBlack: [40, 49],
   bgRed: [41, 49],
@@ -56,6 +65,15 @@ var codes = {
   bgMagenta: [45, 49],
   bgCyan: [46, 49],
   bgWhite: [47, 49],
+  
+  brightBgBlack: [100, 49],
+  brightBgRed: [101, 49],
+  brightBgGreen: [102, 49],
+  brightBgYellow: [103, 49],
+  brightBgBlue: [104, 49],
+  brightBgMagenta: [105, 49],
+  brightBgCyan: [106, 49],
+  brightBbgWhite: [107, 49],
 
   // legacy styles for colors pre v1.0.0
   blackBG: [40, 49],


### PR DESCRIPTION
Dear Owner and/or Maintainer,

I find it a travesty that the "bright" ANSI colors were omitted from `lib/styles.js`. In a form of agreeable protest, I have opened a Pull Request containing code that should be reviewed and consequently approved as soon as possible. I have high confidence that this Pull Request meets the basic standards for writing text on successive lines.

Thank you,

`heisian`