### PR TITLE
Document colors.enable() and .disable() in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,12 +94,27 @@ I prefer the first way. Some people seem to be afraid of extending `String.proto
 
 If you are writing good code you will never have an issue with the first approach. If you really don't want to touch `String.prototype`, the second usage will not touch `String` native object.
 
-## Disabling Colors
+## Enabling/Disabling Colors
 
-To disable colors you can pass the following arguments in the command line to your application:
+The package will auto-detect whether your terminal can use colors and enable/disable accordingly. When colors are disabled, the color functions do nothing. You can override this with a command-line flag:
 
 ```bash
 node myapp.js --no-color
+node myapp.js --color=false
+
+node myapp.js --color
+node myapp.js --color=true
+node myapp.js --color=always
+
+FORCE_COLOR=1 node myapp.js
+```
+
+Or in code:
+
+```javascript
+var colors = require('colors');
+colors.enable();
+colors.disable();
 ```
 
 ## Console.log [string substitution](http://nodejs.org/docs/latest/api/console.html#console_console_log_data)


### PR DESCRIPTION
Resolves #251 requesting documentation for the enable/disable functions. This documents them in the readme. My explanation doesn't really fit the tone of the rest of the readme, so I'm open to changing the wording