### PR TITLE
fix null exception

### DIFF
--- a/lib/colors.js
+++ b/lib/colors.js
@@ -105,7 +105,7 @@ function applyStyle() {
   var args = Array.prototype.slice.call(arguments);
 
   var str = args.map(function(arg) {
-    if (arg !== undefined && arg.constructor === String) {
+    if (arg != null && arg.constructor === String) {
       return arg;
     } else {
       return util.inspect(arg);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "colors",
-    "version": "1.3.3",
+    "version": "1.3.4",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "colors",
     "description": "get colors in your node.js console",
-    "version": "1.3.3",
+    "version": "1.3.4",
     "author": "Marak Squires",
     "contributors": [
         {

--- a/tests/safe-test.js
+++ b/tests/safe-test.js
@@ -66,3 +66,10 @@ colors.setTheme({custom: ['red', 'italic', 'inverse']});
 assert.equal(colors.custom(s),
     '\x1b[7m' + '\x1b[3m' + '\x1b[31m' + s +
   '\x1b[39m' + '\x1b[23m' + '\x1b[27m' );
+
+// should not throw error on null or undefined values
+var undef;
+assert.equal(colors.yellow(undef), '\x1b[33mundefined\x1b[39m');
+
+// was failing:
+assert.equal(colors.red(null), '\x1b[31mnull\x1b[39m');


### PR DESCRIPTION
Fixed: throws non-intuitive error on color.red(null) but not on colors.red(undefined)

Includes tests which show the error

Extends on a8ce90c to work for `null` as well as `undefined`.
@DABH 