### PR TITLE
add: link to replit run

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = "cd examples && node safe-string.js"

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![version](https://img.shields.io/npm/v/colors.svg)](https://www.npmjs.org/package/colors)
 [![dependencies](https://david-dm.org/Marak/colors.js.svg)](https://david-dm.org/Marak/colors.js)
 [![devDependencies](https://david-dm.org/Marak/colors.js/dev-status.svg)](https://david-dm.org/Marak/colors.js#info=devDependencies)
+[![run on repl.it](http://repl.it/badge/github/Marak/colors.js)](https://repl.it/github/Marak/colors.js)
 
 Please check out the [roadmap](ROADMAP.md) for upcoming features and releases.  Please open Issues to provide feedback, and check the `develop` branch for the latest bleeding-edge updates.
 


### PR DESCRIPTION
i think it would be pretty cool to let people see how this code works (and edit / preview the program) right in their browser, without any manual downloads or installation. i'm thinking we can add a 'run on repl.it' button, which redirects to something like [this](https://repl.it/@eankeen/run-colors.js):

![image](https://i.imgur.com/LAeQ8Ti.png)
