### PR TITLE
Fix breaking argv change in Chromium 89.0.4389.86

### DIFF
--- a/lib/system/has-flag.js
+++ b/lib/system/has-flag.js
@@ -25,7 +25,7 @@ SOFTWARE.
 'use strict';
 
 module.exports = function(flag, argv) {
-  argv = argv || process.argv;
+  argv = argv || process.argv || [];
 
   var terminatorPos = argv.indexOf('--');
   var prefix = /^-{1,2}/.test(flag) ? '' : '--';


### PR DESCRIPTION
We take a dependency on Winston, which takes a dependency on colors.js. This morning our dev team upgraded to Chromium 89.0.4389.86, which does not guarantee that `process` has an argv field, causing site-breaking changes to projects that take dependency on colors.

![Process Error](https://user-images.githubusercontent.com/2185016/111213528-36c75d80-85a7-11eb-9e6d-bbd514a536c0.png)

This updates so if there is no argv, it resorts to an empty array (alternate behavior may be desired).
