### PR TITLE
Handled undefined args while checking whether colors are supported or not

### DIFF
--- a/lib/system/has-flag.js
+++ b/lib/system/has-flag.js
@@ -25,7 +25,7 @@ SOFTWARE.
 'use strict';
 
 module.exports = function(flag, argv) {
-  argv = argv || process.argv;
+  argv = argv || process.argv || '';
 
   var terminatorPos = argv.indexOf('--');
   var prefix = /^-{1,2}/.test(flag) ? '' : '--';


### PR DESCRIPTION
Failing to handle invalid or not available process args, this happens if we are trying to access colors library in NextJS middleware.

Stacktrace:
 ⨯ Error [TypeError]: Cannot read properties of undefined (reading 'indexOf')
    at <unknown> (webpack-internal:///(middleware)/../../../node_modules/colors/lib/system/has-flag.js:30)
    at module.exports (webpack-internal:///(middleware)/../../../node_modules/colors/lib/system/has-flag.js:30:28)
    at eval (webpack-internal:///(middleware)/../../../node_modules/colors/lib/system/supports-colors.js:34:5)
    at (middleware)/../../node_modules/colors/lib/system/supports-colors.js (file:///.../dist/.next/server/src/middleware.js:964:1)
    at __webpack_require__ (file:///.../.next/server/edge-runtime-webpack.js:37:33)
    at fn (file:///.../.next/server/edge-runtime-webpack.js:294:21)